### PR TITLE
Check employment status via API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source :rubygems
 
 gem 'rack'
 gem 'sinatra'
+gem 'json'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,7 @@
 GEM
+  remote: http://rubygems.org/
   specs:
+    json (1.5.1)
     rack (1.2.1)
     sinatra (1.1.0)
       rack (~> 1.1)
@@ -10,5 +12,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  json
   rack
   sinatra

--- a/amiworkingforgithubnow.rb
+++ b/amiworkingforgithubnow.rb
@@ -1,48 +1,24 @@
 require 'rubygems'
 require 'sinatra'
+require 'json'
+require 'net/https'
 
 mime_type :ttf, "application/octet-stream"
 mime_type :woff, "application/octet-stream"
-
-GITHUB_HANDLES = %w(
-  amiridis
-  atmos
-  bleikamp
-  brianmario
-  bryanveloso
-  cameronmcefee
-  defunkt
-  demonbane
-  eston
-  firstdegree
-  holman
-  joshaber
-  kevinsawicki
-  kneath
-  luckiestmonkey
-  mislav
-  mojombo
-  peff
-  pjhyett
-  probablycorey
-  rodjek
-  rtomayko
-  schacon
-  sr
-  tanoku
-  tater
-  tclem
-  technoweenie
-  tekkub
-  tmm1
-)
 
 get '/' do
   erb :index
 end
 
 post '/working' do
-  if GITHUB_HANDLES.include?(params[:handle].downcase)
+  req = Net::HTTP::Get.new("/api/v2/json/user/show/#{params[:handle].downcase}/organizations")
+
+  http = Net::HTTP.new("github.com", 443)
+  http.use_ssl = true
+
+  myorgs = JSON.parse(http.request(req).body)["organizations"]
+
+  if !myorgs.select {|org| org["name"].eql?("GitHub")}.empty?
     erb :yes
   else
     erb :no


### PR DESCRIPTION
If you'd like to get away from having to manually update that array every time someone starts at GH, you can use this to query our API directly. And nothing secret here, this is straight from http://develop.github.com/p/orgs.html.
